### PR TITLE
Do not prepend the NakayoshiFork module to Object

### DIFF
--- a/lib/nakayoshi_fork.rb
+++ b/lib/nakayoshi_fork.rb
@@ -1,30 +1,30 @@
 require "nakayoshi_fork/version"
 
 module NakayoshiFork
-  def fork(nakayoshi: true, cow_friendly: true, &b)
-    if nakayoshi && cow_friendly
-      h = {}
-      4.times{ # maximum 4 times
-        GC.stat(h)
-        live_slots = h[:heap_live_slots] || h[:heap_live_slot]
-        old_objects = h[:old_objects] || h[:old_object]
-        remwb_unprotects = h[:remembered_wb_unprotected_objects] || h[:remembered_shady_object]
-        young_objects = live_slots - old_objects - remwb_unprotects
+  module Behavior
+    def fork(nakayoshi: true, cow_friendly: true, &b)
+      if nakayoshi && cow_friendly
+        h = {}
+        4.times{ # maximum 4 times
+          GC.stat(h)
+          live_slots = h[:heap_live_slots] || h[:heap_live_slot]
+          old_objects = h[:old_objects] || h[:old_object]
+          remwb_unprotects = h[:remembered_wb_unprotected_objects] || h[:remembered_shady_object]
+          young_objects = live_slots - old_objects - remwb_unprotects
 
-        # p [[live_slots, old_objects, remwb_unprotects], [young_objects]]
+          break if young_objects < live_slots / 10
 
-        break if young_objects < live_slots / 10
+          disabled = GC.enable
+          GC.start(full_mark: false)
+          GC.disable if disabled
+        }
+      end
 
-        disabled = GC.enable
-        GC.start(full_mark: false)
-        GC.disable if disabled
-      }
-    end
-
-    super(&b)
-  end if GC.method(:start).arity != 0
+      super(&b)
+    end if GC.method(:start).arity != 0
+  end
 end
 
 class Object
-  prepend NakayoshiFork
+  prepend NakayoshiFork::Behavior
 end


### PR DESCRIPTION
NakayoshiFork has a VERSION constant and prepending it to Object will
make all class to have a VERSION constant defined.

```ruby
>> module Foo
>>   VERSION = 1
>>   end
=> 1
>> class Object
>>   prepend Foo
>>   end
=> Object
>> Object::VERSION
=> 1
>> String::VERSION
=> 1
>> module Bar
>>   end
=> nil
>> defined?(Bar::VERSION)
=> nil
>> Bar::VERSION
NameError: uninitialized constant Bar::VERSION
Did you mean?  VERSION
    from (irb):12
    from /opt/rubies/2.4.4/bin/irb:11:in `<main>'
>> class Baz
>>   end
=> nil
>> defined?(Baz::VERSION)
=> "constant"
>> Baz::VERSION
=> 1
```

```ruby
>> module Foo
>>   VERSION = 1
>>   module Bar
>>     end
>>   end
=> nil
>> class Object
>>   prepend Foo::Bar
>>   end
=> Object
>> String::VERSION
NameError: uninitialized constant String::VERSION
	from (irb):9
	from /opt/rubies/2.4.4/bin/irb:11:in `<main>'
```